### PR TITLE
enhancement: Updated GHA and GLA pipelines to use newly released Fortify GHA and CI Tools Image

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fortify SAST Assessment
-        uses: fortify/github-action@v1
+        uses: fortify/github-action@v2
         with:
           sast-scan: true
         env:

--- a/gitlab-ci/fortify.yml
+++ b/gitlab-ci/fortify.yml
@@ -7,7 +7,7 @@ variables:
 
 fortify-sast:
   stage: test
-  image: fortifydocker/fortify-ci-tools:6.2-jdk-21
+  image: fortifydocker/fortify-ci-tools:7-jdk-21
   before_script:
     - mkdir .fortify
     # ScanCentral SAST Client Auth Token
@@ -18,19 +18,14 @@ fortify-sast:
     - >
       fcli ssc session login 
       --token "$SSC_TOKEN" 
-      --url "$SSC_URL" 
-    - >
-      fcli sc-sast session login 
       --client-auth-token "$CLIENT_AUTH_TOKEN"
-      --ssc-ci-token "$SSC_TOKEN" 
-      --ssc-url "$SSC_URL" 
+      --url "$SSC_URL" 
     - > 
       fcli sc-sast scan start 
-      --package-file package.zip 
+      --file package.zip 
       --publish-to "$SSC_APP_NAME:$SSC_APP_VER_NAME" 
       --sensor-version 24.4 
       --store jobtoken 
-    - fcli sc-sast session logout --no-revoke-token 
     - fcli ssc session logout
     # - >
     #   scancentral -url "$SCSAST_URL/scancentral-ctrl" -ssctoken "$SSC_TOKEN" start 


### PR DESCRIPTION
### GitHub
* Update to fortify/github-action@v2

### GitLab
* Update GitLab pipeline to use fortify-ci-tools:7-jdk-21 image
* Updated fcli command to use syntax based on v3.4.1